### PR TITLE
fix: correct namespace and using for PersonModel

### DIFF
--- a/Models/PersonModel.cs
+++ b/Models/PersonModel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Person.routes.Models
+namespace Person.Models
 {
     public class PersonModel
     {

--- a/routes/PersonRoute.cs
+++ b/routes/PersonRoute.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Person.routes.Models;
+using Person.Models;
 
 namespace Person.route
 {


### PR DESCRIPTION
Este PR corrige o namespace e o using da classe PersonModel, garantindo que a referência ao modelo esteja correta em todo o projeto.