### PR TITLE
feat: implement POST endpoint to create and persist person using PersonContext

### DIFF
--- a/routes/PersonRoute.cs
+++ b/routes/PersonRoute.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Person.Data;
 using Person.Models;
 
 namespace Person.route
@@ -10,7 +11,22 @@ namespace Person.route
     {
         public static void PersonRoutes(this WebApplication app)
         {
-            app.MapGet("person", () => new PersonModel("Deizi"));
+          //  app.MapGet("person", () => new PersonModel("Deizi"));
+          var route = app.MapGroup("person");
+          route.MapPost("", async (PersonRequest req, PersonContext context) =>
+          {
+              //criando a instância de uma pessoa, passando o parâmetro construido na classe record (name)
+              var person = new PersonModel(req.name);
+              
+              //utilizando recurso do context(Banco de dados)
+              //Resumo: crie uma pessoa pra mim com o nome que eu passei e adicione ela dentro do context(Banco de dados)
+              //OBS: isso não garante que ela (person) vai estar no banco de dados, até que seja feito o commit
+              await context.AddAsync(person);
+              
+              //Fazendo o commit,
+              //ele basicamente vai ao banco de dados, no sql server e faz o commit
+              await context.SaveChangesAsync();
+          });
 
         }  
         


### PR DESCRIPTION
Este PR adiciona um endpoint POST para criação de pessoas.
Ao receber uma requisição, o endpoint instancia um objeto PersonModel utilizando o parâmetro name fornecido na requisição (classe record).
A nova pessoa é adicionada ao contexto do banco de dados (PersonContext) com o método AddAsync, preparando-a para ser persistida.
A gravação efetiva no banco ocorre somente após a chamada de SaveChangesAsync, que realiza o commit da transação e garante que a pessoa seja salva no banco de dados SQLite.
Dessa forma, o fluxo implementa corretamente a criação e persistência de registros de pessoas via API.