### PR TITLE
chore: add .gitignore to exclude build and IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ obj/
 
 # Configurações locais
 appsettings.Development.json
+.idea/
+*.sqlite-wal
+*.sqlite-shm


### PR DESCRIPTION
Este PR atualiza o arquivo .gitignore do projeto, incluindo novas regras para ignorar arquivos e pastas gerados automaticamente ou desnecessários para o versionamento.
A atualização garante que o repositório permaneça organizado e livre de arquivos temporários ou específicos de ambiente de desenvolvimento.